### PR TITLE
Fix spec file for RHEL

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ $script = <<SCRIPT
     pip install -r /opt/resultsdb-updater/src/requirements.txt
     pip install -r /opt/resultsdb-updater/src/test-requirements.txt
     cd /opt/resultsdb-updater/src
-    python setup.py develop
+    python setup.py egg_info
 SCRIPT
 
 Vagrant.configure("2") do |config|

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fedmsg
 m2crypto
 m2ext
-moksha
+moksha.hub
 psutil
 qpid-python
 stomper

--- a/resultsdb-updater.spec
+++ b/resultsdb-updater.spec
@@ -22,7 +22,7 @@ BuildRequires:      python-setuptools
 
 Requires:           fedmsg
 Requires:           m2crypto
-Requires:           moksha
+Requires:           python-moksha-hub
 Requires:           python-fedmsg-commands
 Requires:           python-fedmsg-consumers
 Requires:           python-m2ext


### PR DESCRIPTION
EPEL7 does not contain the package `moksha`, but it does contain `python-moksha-hub`. This PR changes the name for RHEL7 installations to work.