### PR TITLE
Add item and type in results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ export/
 .DS_Store
 .vagrant/
 ciconsumer.egg-info
+ca.crt

--- a/fedmsg.d/config.py
+++ b/fedmsg.d/config.py
@@ -11,6 +11,6 @@ config = {
     'stomp_user': 'user',
     'stomp_pass': 'password',
     'resultsdb-updater.log_level': logging.INFO,
-    'resultsdb-updater.resultsdb_api_url': 'http://resultsdb.domain.local/api/v1.0',
+    'resultsdb-updater.resultsdb_api_url': 'https://resultsdb.domain.local/api/v1.0',
     'resultsdb-updater.resultsdb_api_ca': None
 }

--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -96,6 +96,12 @@ def post_to_resultsdb(msg):
     job_name = msg['body']['msg']['job_names']
     job_url = msg['body']['msg']['job_link_back']
     job_tests = msg['body']['msg'].get('tests')
+    job_component = msg['body']['msg'].get('component', 'unknown')
+
+    if msg['body']['msg'].get('brew_task_id'):
+        job_type = 'koji_build'
+    else:
+        job_type = 'unknown'
 
     if not job_tests:
         LOGGER.warn((
@@ -120,6 +126,9 @@ def post_to_resultsdb(msg):
                 outcome = 'PASSED'
             else:
                 outcome = 'FAILED'
+
+            test['item'] = job_component
+            test['type'] = job_type
 
             if not create_result(testcase_name, job_id, outcome,
                                  result_data=test):

--- a/tests/cassettes/consume_msg_one_success.yaml
+++ b/tests/cassettes/consume_msg_one_success.yaml
@@ -9,17 +9,17 @@ interactions:
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/jobs
+    uri: https://resultsdb.domain.local/api/v1.0/jobs
   response:
-    body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"http://resultsdb.domain.local/api/v1.0/jobs/2\"\
-        , \n  \"id\": 2, \n  \"name\": \"myjobname\", \n  \"ref_url\": \"TESTURL\"\
+    body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"https://resultsdb.domain.local/api/v1.0/jobs/1\"\
+        , \n  \"id\": 1, \n  \"name\": \"myjobname\", \n  \"ref_url\": \"TESTURL\"\
         , \n  \"results\": [], \n  \"results_count\": 0, \n  \"start_time\": null,\
         \ \n  \"status\": \"CRASHED\", \n  \"uuid\": null\n}"}
     headers:
       connection: [Keep-Alive]
       content-length: ['273']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:06:04 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:40 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -27,3 +27,4 @@ interactions:
       x-content-type-options: [nosniff]
       x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
+version: 1

--- a/tests/cassettes/consume_msg_three_success.yaml
+++ b/tests/cassettes/consume_msg_three_success.yaml
@@ -10,10 +10,10 @@ interactions:
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/jobs
+    uri: https://resultsdb.domain.local/api/v1.0/jobs
   response:
-    body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"http://resultsdb.domain.local/api/v1.0/jobs/4\"\
-        , \n  \"id\": 4, \n  \"name\": \"package-rhel-7.2-candidate-runtest-fslock-func\"\
+    body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"https://resultsdb.domain.local/api/v1.0/jobs/2\"\
+        , \n  \"id\": 2, \n  \"name\": \"package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n  \"ref_url\": \" http://domain.local/job-package-4.4.4-7.el7\", \n  \"\
         results\": [], \n  \"results_count\": 0, \n  \"start_time\": null, \n  \"\
         status\": \"RUNNING\", \n  \"uuid\": null\n}"}
@@ -21,7 +21,7 @@ interactions:
       connection: [Keep-Alive]
       content-length: ['347']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:14:36 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:42 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -30,33 +30,35 @@ interactions:
       x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
 - request:
-    body: !!python/unicode '{"result_data": {"failed": "0", "executed": "25", "arch":
-      "aarch64", "executor": "beaker"}, "outcome": "PASSED", "job_id": 4, "testcase_name":
-      "someteam.package-rhel-7.2-candidate-runtest-fslock-func"}'
+    body: !!python/unicode '{"result_data": {"executed": "25", "item": "package-4.4.4-7.el7",
+      "arch": "aarch64", "failed": "0", "executor": "beaker", "type": "koji_build"},
+      "outcome": "PASSED", "job_id": 2, "testcase_name": "someteam.package-rhel-7.2-candidate-runtest-fslock-func"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['202']
+      Content-Length: ['254']
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/results
+    uri: https://resultsdb.domain.local/api/v1.0/results
   response:
-    body: {string: !!python/unicode "{\n  \"href\": \"http://resultsdb.domain.local/api/v1.0/results/4\"\
-        , \n  \"id\": 4, \n  \"job_url\": \"http://resultsdb.domain.local/api/v1.0/jobs/4\"\
+    body: {string: !!python/unicode "{\n  \"href\": \"https://resultsdb.domain.local/api/v1.0/results/1\"\
+        , \n  \"id\": 1, \n  \"job_url\": \"https://resultsdb.domain.local/api/v1.0/jobs/2\"\
         , \n  \"log_url\": null, \n  \"outcome\": \"PASSED\", \n  \"result_data\"\
         : {\n    \"arch\": [\n      \"aarch64\"\n    ], \n    \"executed\": [\n  \
         \    \"25\"\n    ], \n    \"executor\": [\n      \"beaker\"\n    ], \n   \
-        \ \"failed\": [\n      \"0\"\n    ]\n  }, \n  \"submit_time\": \"2016-12-01T15:14:37.604620\"\
-        , \n  \"summary\": null, \n  \"testcase\": {\n    \"href\": \"http://resultsdb.domain.local/api/v1.0/testcases/someteam.package-rhel-7.2-candidate-runtest-fslock-func\"\
+        \ \"failed\": [\n      \"0\"\n    ], \n    \"item\": [\n      \"package-4.4.4-7.el7\"\
+        \n    ], \n    \"type\": [\n      \"koji_build\"\n    ]\n  }, \n  \"submit_time\"\
+        : \"2016-12-02T20:42:44.353011\", \n  \"summary\": null, \n  \"testcase\"\
+        : {\n    \"href\": \"https://resultsdb.domain.local/api/v1.0/testcases/someteam.package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n    \"name\": \"someteam.package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n    \"url\": \"\"\n  }\n}"}
     headers:
       connection: [Keep-Alive]
-      content-length: ['731']
+      content-length: ['819']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:14:37 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:44 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -65,33 +67,35 @@ interactions:
       x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
 - request:
-    body: !!python/unicode '{"result_data": {"failed": "0", "executed": "1000", "arch":
-      "x86_64", "executor": "CI-OSP"}, "outcome": "PASSED", "job_id": 4, "testcase_name":
-      "someteam.package-rhel-7.2-candidate-runtest-fslock-func"}'
+    body: !!python/unicode '{"result_data": {"executed": "1000", "item": "package-4.4.4-7.el7",
+      "arch": "x86_64", "failed": "0", "executor": "CI-OSP", "type": "koji_build"},
+      "outcome": "PASSED", "job_id": 2, "testcase_name": "someteam.package-rhel-7.2-candidate-runtest-fslock-func"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['203']
+      Content-Length: ['255']
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/results
+    uri: https://resultsdb.domain.local/api/v1.0/results
   response:
-    body: {string: !!python/unicode "{\n  \"href\": \"http://resultsdb.domain.local/api/v1.0/results/5\"\
-        , \n  \"id\": 5, \n  \"job_url\": \"http://resultsdb.domain.local/api/v1.0/jobs/4\"\
+    body: {string: !!python/unicode "{\n  \"href\": \"https://resultsdb.domain.local/api/v1.0/results/2\"\
+        , \n  \"id\": 2, \n  \"job_url\": \"https://resultsdb.domain.local/api/v1.0/jobs/2\"\
         , \n  \"log_url\": null, \n  \"outcome\": \"PASSED\", \n  \"result_data\"\
         : {\n    \"arch\": [\n      \"x86_64\"\n    ], \n    \"executed\": [\n   \
         \   \"1000\"\n    ], \n    \"executor\": [\n      \"CI-OSP\"\n    ], \n  \
-        \  \"failed\": [\n      \"0\"\n    ]\n  }, \n  \"submit_time\": \"2016-12-01T15:14:38.918326\"\
-        , \n  \"summary\": null, \n  \"testcase\": {\n    \"href\": \"http://resultsdb.domain.local/api/v1.0/testcases/someteam.package-rhel-7.2-candidate-runtest-fslock-func\"\
+        \  \"failed\": [\n      \"0\"\n    ], \n    \"item\": [\n      \"package-4.4.4-7.el7\"\
+        \n    ], \n    \"type\": [\n      \"koji_build\"\n    ]\n  }, \n  \"submit_time\"\
+        : \"2016-12-02T20:42:45.788664\", \n  \"summary\": null, \n  \"testcase\"\
+        : {\n    \"href\": \"https://resultsdb.domain.local/api/v1.0/testcases/someteam.package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n    \"name\": \"someteam.package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n    \"url\": \"\"\n  }\n}"}
     headers:
       connection: [Keep-Alive]
-      content-length: ['732']
+      content-length: ['820']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:14:38 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:45 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -109,14 +113,14 @@ interactions:
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: PUT
-    uri: http://resultsdb.domain.local/api/v1.0/jobs/4
+    uri: https://resultsdb.domain.local/api/v1.0/jobs/2
   response:
     body: {string: !!python/unicode '{}'}
     headers:
       connection: [Keep-Alive]
       content-length: ['2']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:14:40 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:47 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]

--- a/tests/cassettes/consume_msg_two_success.yaml
+++ b/tests/cassettes/consume_msg_two_success.yaml
@@ -10,9 +10,9 @@ interactions:
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/jobs
+    uri: https://resultsdb.domain.local/api/v1.0/jobs
   response:
-    body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"http://resultsdb.domain.local/api/v1.0/jobs/3\"\
+    body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"https://resultsdb.domain.local/api/v1.0/jobs/3\"\
         , \n  \"id\": 3, \n  \"name\": \"package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n  \"ref_url\": \" http://domain.local/job-package-4.4.4-6.el7\", \n  \"\
         results\": [], \n  \"results_count\": 0, \n  \"start_time\": null, \n  \"\
@@ -21,7 +21,7 @@ interactions:
       connection: [Keep-Alive]
       content-length: ['347']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:06:07 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:48 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -30,33 +30,35 @@ interactions:
       x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
 - request:
-    body: !!python/unicode '{"result_data": {"failed": "1", "executed": "20", "arch":
-      "aarch64", "executor": "beaker"}, "outcome": "FAILED", "job_id": 3, "testcase_name":
-      "unassigned\\package-rhel-7.2-candidate-runtest-fslock-func"}'
+    body: !!python/unicode '{"result_data": {"executed": "20", "item": "package-4.4.4-6.el7",
+      "arch": "aarch64", "failed": "1", "executor": "beaker", "type": "koji_build"},
+      "outcome": "FAILED", "job_id": 3, "testcase_name": "unassigned.package-rhel-7.2-candidate-runtest-fslock-func"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['204']
+      Content-Length: ['256']
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/results
+    uri: https://resultsdb.domain.local/api/v1.0/results
   response:
-    body: {string: !!python/unicode "{\n  \"href\": \"http://resultsdb.domain.local/api/v1.0/results/2\"\
-        , \n  \"id\": 2, \n  \"job_url\": \"http://resultsdb.domain.local/api/v1.0/jobs/3\"\
+    body: {string: !!python/unicode "{\n  \"href\": \"https://resultsdb.domain.local/api/v1.0/results/3\"\
+        , \n  \"id\": 3, \n  \"job_url\": \"https://resultsdb.domain.local/api/v1.0/jobs/3\"\
         , \n  \"log_url\": null, \n  \"outcome\": \"FAILED\", \n  \"result_data\"\
         : {\n    \"arch\": [\n      \"aarch64\"\n    ], \n    \"executed\": [\n  \
         \    \"20\"\n    ], \n    \"executor\": [\n      \"beaker\"\n    ], \n   \
-        \ \"failed\": [\n      \"1\"\n    ]\n  }, \n  \"submit_time\": \"2016-12-01T15:06:08.379144\"\
-        , \n  \"summary\": null, \n  \"testcase\": {\n    \"href\": \"http://resultsdb.domain.local/api/v1.0/testcases/unassigned%5Cpackage-rhel-7.2-candidate-runtest-fslock-func\"\
-        , \n    \"name\": \"unassigned\\\\package-rhel-7.2-candidate-runtest-fslock-func\"\
+        \ \"failed\": [\n      \"1\"\n    ], \n    \"item\": [\n      \"package-4.4.4-6.el7\"\
+        \n    ], \n    \"type\": [\n      \"koji_build\"\n    ]\n  }, \n  \"submit_time\"\
+        : \"2016-12-02T20:42:50.162657\", \n  \"summary\": null, \n  \"testcase\"\
+        : {\n    \"href\": \"https://resultsdb.domain.local/api/v1.0/testcases/unassigned.package-rhel-7.2-candidate-runtest-fslock-func\"\
+        , \n    \"name\": \"unassigned.package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n    \"url\": \"\"\n  }\n}"}
     headers:
       connection: [Keep-Alive]
-      content-length: ['735']
+      content-length: ['823']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:06:08 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:50 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -65,33 +67,35 @@ interactions:
       x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
 - request:
-    body: !!python/unicode '{"result_data": {"failed": "54", "executed": "1000", "arch":
-      "x86_64", "executor": "CI-OSP"}, "outcome": "FAILED", "job_id": 3, "testcase_name":
-      "unassigned\\package-rhel-7.2-candidate-runtest-fslock-func"}'
+    body: !!python/unicode '{"result_data": {"executed": "1000", "item": "package-4.4.4-6.el7",
+      "arch": "x86_64", "failed": "54", "executor": "CI-OSP", "type": "koji_build"},
+      "outcome": "FAILED", "job_id": 3, "testcase_name": "unassigned.package-rhel-7.2-candidate-runtest-fslock-func"}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['206']
+      Content-Length: ['258']
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/results
+    uri: https://resultsdb.domain.local/api/v1.0/results
   response:
-    body: {string: !!python/unicode "{\n  \"href\": \"http://resultsdb.domain.local/api/v1.0/results/3\"\
-        , \n  \"id\": 3, \n  \"job_url\": \"http://resultsdb.domain.local/api/v1.0/jobs/3\"\
+    body: {string: !!python/unicode "{\n  \"href\": \"https://resultsdb.domain.local/api/v1.0/results/4\"\
+        , \n  \"id\": 4, \n  \"job_url\": \"https://resultsdb.domain.local/api/v1.0/jobs/3\"\
         , \n  \"log_url\": null, \n  \"outcome\": \"FAILED\", \n  \"result_data\"\
         : {\n    \"arch\": [\n      \"x86_64\"\n    ], \n    \"executed\": [\n   \
         \   \"1000\"\n    ], \n    \"executor\": [\n      \"CI-OSP\"\n    ], \n  \
-        \  \"failed\": [\n      \"54\"\n    ]\n  }, \n  \"submit_time\": \"2016-12-01T15:06:09.745925\"\
-        , \n  \"summary\": null, \n  \"testcase\": {\n    \"href\": \"http://resultsdb.domain.local/api/v1.0/testcases/unassigned%5Cpackage-rhel-7.2-candidate-runtest-fslock-func\"\
-        , \n    \"name\": \"unassigned\\\\package-rhel-7.2-candidate-runtest-fslock-func\"\
+        \  \"failed\": [\n      \"54\"\n    ], \n    \"item\": [\n      \"package-4.4.4-6.el7\"\
+        \n    ], \n    \"type\": [\n      \"koji_build\"\n    ]\n  }, \n  \"submit_time\"\
+        : \"2016-12-02T20:42:51.641983\", \n  \"summary\": null, \n  \"testcase\"\
+        : {\n    \"href\": \"https://resultsdb.domain.local/api/v1.0/testcases/unassigned.package-rhel-7.2-candidate-runtest-fslock-func\"\
+        , \n    \"name\": \"unassigned.package-rhel-7.2-candidate-runtest-fslock-func\"\
         , \n    \"url\": \"\"\n  }\n}"}
     headers:
       connection: [Keep-Alive]
-      content-length: ['737']
+      content-length: ['825']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:06:09 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:51 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]
@@ -109,14 +113,14 @@ interactions:
       User-Agent: [python-requests/2.12.3]
       content-type: [application/json]
     method: PUT
-    uri: http://resultsdb.domain.local/api/v1.0/jobs/3
+    uri: https://resultsdb.domain.local/api/v1.0/jobs/3
   response:
     body: {string: !!python/unicode '{}'}
     headers:
       connection: [Keep-Alive]
       content-length: ['2']
       content-type: [application/json]
-      date: ['Thu, 01 Dec 2016 15:06:11 GMT']
+      date: ['Fri, 02 Dec 2016 20:42:53 GMT']
       keep-alive: ['timeout=5, max=100']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
           Python/2.7.5]

--- a/tests/cassettes/create_job_success.yaml
+++ b/tests/cassettes/create_job_success.yaml
@@ -10,7 +10,7 @@ interactions:
       User-Agent: [python-requests/2.11.1]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/jobs
+    uri: https://resultsdb.domain.local/api/v1.0/jobs
   response:
     body: {string: !!python/unicode "{\n  \"end_time\": null, \n  \"href\": \"http://resultsdb.domain.local/api/v1.0/jobs/10\"\
         , \n  \"id\": 10, \n  \"name\": \"some_job\", \n  \"ref_url\": \"http://someurl.domain.local/path/to/test\"\
@@ -22,6 +22,10 @@ interactions:
       content-type: [application/json]
       date: ['Mon, 21 Nov 2016 21:21:47 GMT']
       keep-alive: ['timeout=5, max=100']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
+          Python/2.7.5]
+      strict-transport-security: [max-age=63072000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
 version: 1

--- a/tests/cassettes/create_result_success.yaml
+++ b/tests/cassettes/create_result_success.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent: [python-requests/2.11.1]
       content-type: [application/json]
     method: POST
-    uri: http://resultsdb.domain.local/api/v1.0/results
+    uri: https://resultsdb.domain.local/api/v1.0/results
   response:
     body: {string: !!python/unicode "{\n  \"href\": \"http://resultsdb.domain.local/api/v1.0/results/2\"\
         , \n  \"id\": 2, \n  \"job_url\": \"http://resultsdb.domain.local/api/v1.0/jobs/10\"\
@@ -27,6 +27,10 @@ interactions:
       content-type: [application/json]
       date: ['Mon, 21 Nov 2016 21:24:02 GMT']
       keep-alive: ['timeout=5, max=100']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
+          Python/2.7.5]
+      strict-transport-security: [max-age=63072000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
     status: {code: 201, message: CREATED}
 version: 1

--- a/tests/cassettes/set_job_status_success.yaml
+++ b/tests/cassettes/set_job_status_success.yaml
@@ -9,7 +9,7 @@ interactions:
       User-Agent: [python-requests/2.11.1]
       content-type: [application/json]
     method: PUT
-    uri: http://resultsdb.domain.local/api/v1.0/jobs/10
+    uri: https://resultsdb.domain.local/api/v1.0/jobs/10
   response:
     body: {string: !!python/unicode '{}'}
     headers:
@@ -18,6 +18,10 @@ interactions:
       content-type: [application/json]
       date: ['Mon, 21 Nov 2016 21:26:35 GMT']
       keep-alive: ['timeout=5, max=100']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4
+          Python/2.7.5]
+      strict-transport-security: [max-age=63072000; includeSubDomains]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
     status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
This adds the `item` field in the `result_data` based on the value of `component` in the CI message. This adds the `type` field in the `result_data`. It is marked as `koji_build` if the `brew_task_id` is in the message, otherwise, it is set to `unknown`.

Additionally, this has the vcrpy tests go against HTTPS instead of HTTP for more accuracy.