### PR TITLE
Added support for recipients field

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -52,6 +52,6 @@ class TestConsumer(unittest.TestCase):
         fake_ref_url = 'http://domain.local/job/package/136/console'
         self.assertEqual(
             utils.create_result(
-                {'name': 'testcase'}, 'PASSED', fake_ref_url, data),
+                {'name': 'testcase'}, 'PASSED', fake_ref_url, data, recipients=['jkulda', 'unknown']),
             True
         )


### PR DESCRIPTION
I tried to add support for recipients field but unfortunately I don't know how to test it. Recipients field contains python list and I don't know how it will be consumed on the other side. 