### PR TITLE
Dynamically determine if a message is a ResultsDB style message

### DIFF
--- a/tests/fake_messages/bogus.json
+++ b/tests/fake_messages/bogus.json
@@ -1,0 +1,19 @@
+{
+  "body": {
+    "msg": {
+      "some_key": "some_value"
+    },
+    "headers": {
+      "destination": "/topic/VirtualTopic.qe.ci.jenkins",
+      "message-id": "ID:server.domain.local-18295-1512954431690-2:858666:0:0:2",
+      "subscription": "/queue/Consumer.client-resultsdb-updater.VirtualTopic.eng.>"
+    },
+    "topic": "/topic/VirtualTopic.qe.ci.jenkins"
+  },
+  "headers": {
+    "destination": "/topic/VirtualTopic.qe.ci.jenkins",
+    "message-id": "ID:server.domain.local-18295-1512954431690-2:858666:0:0:2",
+    "subscription": "/queue/Consumer.client-resultsdb-updater.VirtualTopic.eng.>"
+  },
+  "topic": "/topic/VirtualTopic.qe.ci.jenkins"
+}

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -389,3 +389,11 @@ class TestConsumer(unittest.TestCase):
             testcase_names.pop(testcase_names.index(testcase_name))
         msg = 'Not all the expected testcases were processed'
         assert len(testcase_names) == 0, msg
+
+    def test_full_consume_bogus_msg(self, mock_get_session):
+        fake_msg_path = path.join(self.json_dir, 'bogus.json')
+        with open(fake_msg_path) as fake_msg_file:
+            fake_msg = json.load(fake_msg_file)
+
+        assert self.consumer.consume(fake_msg) is False
+        mock_get_session.assert_not_called()


### PR DESCRIPTION
Instead of hard-coding which topics send ResultsDB style messages, let's just dynamically determine that.