### PR TITLE
Update Dockerfile and add usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,55 @@ Run the service:
 ```
 fedmsg-hub
 ```
+
+### Running the service in a container
+
+Building the container image requires the ResultsDB-Updater rpm to be provided
+as a build argument:
+
+```bash
+$ docker build -f openshift/Dockerfile \
+               --tag <IMAGE_TAG> \
+               --build-arg resultsdb_updater_rpm=<RESULTSDB_UPDATER_RPM> ./
+```
+
+`IMAGE_TAG` is the tag to be applied on the image built.
+
+`RESULTSDB_UPDATER_RPM` is either the URL of the ResultsDB-Updater rpm, or the
+relative path of that rpm *within* the build context.
+
+There are two volumes expected to be mounted when ResultsDB-Updater containers
+are started:
+
+1. A volume mounted at `/etc/fedmsg.d` with any `*.py` file holding fedmsg and
+   ResultsDB-Updater configuration. For an example see `fedmsg.d/config.py` or
+   the documentation on [how to configure
+   fedmsg](http://www.fedmsg.com/en/latest/configuration/#).
+
+2. A volume mounted at `/etc/resultsdb` holding the client certificate and
+   private key files, to be used with STOMP when authenticating with the
+   message broker (if configured).
+
+`openshift/resultsdb-updater-test-template.yaml` defines a
+[template](https://docs.openshift.org/latest/dev_guide/templates.html) to help
+deploying ResultsDB-Updater to OpenShift and connecting it to a ResultsDB
+service, and a message broker (using STOMP).
+
+For the full list of template parameters see:
+
+```bash
+$ oc process -f openshift/resultsdb-updater-test-template.yaml --parameters
+```
+
+For creating the environment run:
+
+```bash
+$ oc process -f openshift/resultsdb-updater-test-template.yaml \
+             -p TEST_ID=<TEST_ID> \
+             -p RESULTSDB_UPDATER_IMAGE=<RESULTSDB_UPDATER_IMAGE> \
+             -p RESULTSDB_API_URL=<RESULTSDB_API_URL> \
+             -p STOMP_URI=<STOMP_URI> | oc apply -f -
+```
+
+Use the `-p` option of `oc process` to override default values of the template
+parameters.

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,16 +1,30 @@
 # This will produce and image to be used in OpenShift
 # Build should be triggered from the repo root like:
-# docker build -f openshift/Dockerfile --tag 172.30.1.1:5000/myproject/resultsdb-updater:latest --build-arg resultsdb_updater_rpm=resultsdb-updater-2.4.0-1.el7eng.noarch.rpm .
-FROM centos:latest
+# docker build -f openshift/Dockerfile \
+#              --tag <IMAGE_TAG> \
+#              --build-arg resultsdb_updater_rpm=<RESULTSDB_UPDATER_RPM> ./
 
+FROM fedora:28
+LABEL \
+    name="ResultsDB-Updater application" \
+    vendor="ResultsDB-Updater developers" \
+    license="LGPL-2.1" \
+    description="ResultsDB-Updater is a micro-service that listens for test \
+results on the CI message bus and updates ResultsDB in a standard format." \
+    usage="https://github.com/release-engineering/resultsdb-updater" \
+    build-date=""
+
+# The caller should build a resultsdb-updater RPM package used and then
+# pass it in this arg.
+# Accept both a URL or a local path relative to the build context.
 ARG resultsdb_updater_rpm
-COPY $resultsdb_updater_rpm /tmp
+ADD $resultsdb_updater_rpm /tmp
 
-RUN yum install -y epel-release && \
-    yum update -y && \
-    yum install -y --setopt=tsflags=nodocs \
+RUN dnf -y update && \
+    dnf -y install --setopt=tsflags=nodocs \
         /tmp/$(basename $resultsdb_updater_rpm) && \
-    yum -y clean all && \
+    dnf -y clean all && \
     rm -f /tmp/$(basename $resultsdb_updater_rpm)
 
+VOLUME ["/etc/resultsdb", "/etc/fedmsg.d"]
 ENTRYPOINT fedmsg-hub


### PR DESCRIPTION
In order to sync with Greenwave and WaiverDB in terms of
how the container images are built, this will update the
Dockerfile to use Fedora as a base image, add some labels,
and document expected volumes.

Update the README to document how to build and use the
container image and the OpenShift template.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>