### PR TITLE
Fix unique value for item column for compose tests in resultsdb_frontend

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -236,7 +236,10 @@ def handle_ci_umb(msg):
         system = system[0] if system else {}
 
     if item_type == 'productmd-compose':
-        item = msg_body['artifact']['compose_id']
+        architecture = system['architecture']
+        variant = system.get('variant')
+        compose_id = msg_body['artifact']['compose_id']
+        item = '{0}/{1}/{2}'.format(compose_id, variant or 'unknown', architecture)
         result_data = {
             key: value for key, value in (
                 ('item', item),
@@ -250,11 +253,11 @@ def handle_ci_umb(msg):
                 ('log', msg_body['run']['log']),
 
                 ('type', item_type),
-                ('productmd.compose.id', item),
+                ('productmd.compose.id', compose_id),
 
                 ('system_provider', system['provider']),
-                ('system_architecture', system['architecture']),
-                ('system_variant', system.get('variant')),
+                ('system_architecture', architecture),
+                ('system_variant', variant),
 
                 ('category', msg_body.get('category')),
             ) if value is not None

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -691,7 +691,7 @@ def test_full_consume_compose_msg(mock_get_session):
         'ref_url': url,
         'note': '',
         'data': {
-            'item': 'RHEL-X.0-20180101.1',
+            'item': 'RHEL-X.0-20180101.1/unknown/x86_64',
             'productmd.compose.id': 'RHEL-X.0-20180101.1',
             'type': 'productmd-compose',
             'category': 'functional',


### PR DESCRIPTION
Instead of just using compose ID to identify test results, use
'compose_id/variant/architecture'.