### PR TITLE
ci_umb: we need to distinguish between scratch builds

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -274,6 +274,10 @@ def handle_ci_umb(msg):
         if not isinstance(scratch, bool):
             scratch = scratch.lower() == 'true'
 
+        # we need to differentiate between scratch and non-scratch builds
+        if scratch:
+            item_type += '_scratch'
+
         result_data = {
             'item': item,
             'type': item_type,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -230,7 +230,7 @@ def test_full_consume_cips_msg(mock_get_session):
     all_expected_data = {
         'data': {
             'item': 'setup-2.8.71-7.el7_4',
-            'type': 'brew-build',
+            'type': 'brew-build_scratch',
 
             'component': 'setup',
             'brew_task_id': 15477983,
@@ -424,7 +424,7 @@ def test_full_consume_pipeline_failure_msg(mock_get_session):
     all_expected_data = {
         'data': {
             'item': 'tigervnc-1.8.0-5.el9000+5',
-            'type': 'brew-build',
+            'type': 'brew-build_scratch',
 
             'component': 'tigervnc',
             'brew_task_id': '15665813',
@@ -483,7 +483,7 @@ def test_full_consume_platformci_success_msg(mock_get_session):
     all_expected_data = {
         'data': {
             'item': 'setup-2.8.71-7.el7_4',
-            'type': 'brew-build',
+            'type': 'brew-build_scratch',
             'component': 'setup',
             'brew_task_id': '15667760',
             'category': 'functional',
@@ -545,7 +545,7 @@ def test_full_consume_osci_success_msg(mock_get_session):
     all_expected_data = {
         'data': {
             'item': 'passwd-0.80-1.el8+5',
-            'type': 'brew-build',
+            'type': 'brew-build_scratch',
             'component': 'passwd',
             'brew_task_id': '15801580',
             'category': 'functional',
@@ -616,7 +616,7 @@ def test_full_consume_osci_example_2(mock_get_session, namespace, expected):
     all_expected_data = {
         'data': {
             'item': 'libfoo-2.7-9.el8+6',
-            'type': 'brew-build',
+            'type': 'brew-build_scratch',
             'component': 'libfoo',
             'brew_task_id': '16000903',
             'category': 'functional',


### PR DESCRIPTION
So we can simply differentiate them with Greenwave.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>