### PR TITLE
Wait for Travis CI results before building an image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,64 @@ pipeline {
     }
 
     stages {
+        stage('Wait for Travis CI results') {
+            steps {
+                script {
+                    def commit = sh(script: "git rev-parse HEAD",
+                                    returnStdout: true).trim()
+                    def repo = 'release-engineering/resultsdb-updater'
+                    def url = "https://api.travis-ci.org/repos/${repo}/builds"
+
+                    def build = null
+
+                    // try finding a Travis build for this commit for a minute or so
+                    for (int i = 0; i < 4; i++) {
+                        if (i > 0) { sleep(20) }
+
+                        def response = sh(script: "curl -s ${url}",
+                                          returnStdout: true).trim()
+                        def json = new groovy.json.JsonSlurper().parseText(response)
+
+                        for (b in json) {
+                            if (b.commit.startsWith(commit)) {
+                                build = b
+                                break
+                            }
+                        }
+
+                        if (build != null) { break }
+                    }
+
+                    if (build == null) {
+                        error("No build found for commit ${commit}")
+                    }
+
+                    // wait for the build to finish for 15 minutes or so
+                    for (int i = 0; i < 31; i++) {
+                        if (build.state == 'finished') {
+                            break
+                        } else {
+                            if (i > 0) { sleep(30) }
+
+                            def response = sh(script: "curl -s ${url}/${build.id}",
+                                              returnStdout: true).trim()
+                            build = new groovy.json.JsonSlurper().parseText(response)
+                        }
+                    }
+
+                    def build_url = "https://travis-ci.org/${repo}/builds/${build.id}"
+
+                    if (build.state != 'finished') {
+                        error("Travis CI build is taking too long: ${build_url}")
+                    }
+
+                    if (build.result != 0) {
+                        error("Travis CI failed: ${build_url}")
+                    }
+                }
+            }
+        }
+
         stage('Build container image') {
             steps {
                 script {
@@ -34,9 +92,6 @@ pipeline {
         }
 
         stage('Apply "latest" tag') {
-            when {
-                branch 'master'
-            }
             steps {
                 echo 'TODO'
             }


### PR DESCRIPTION
This will check Travis CI API a few times to find the build for the
corresponding commit and wait for it to finish, before building
a container image from the code.