### PR TITLE
Make Basic HTTP authentication configurable

### DIFF
--- a/fedmsg.d/config.py
+++ b/fedmsg.d/config.py
@@ -17,5 +17,9 @@ config = {
     'resultsdb-updater.log_level': logging.INFO,
     'resultsdb-updater.resultsdb_api_url': 'https://resultsdb.domain.local/api/v2.0',
     'resultsdb-updater.resultsdb_api_ca': None,
+    # User and password for ResultsDB HTTP Basic authentication.
+    # Used only for creating results.
+    # 'resultsdb-updater.resultsdb_user': 'resultsdb-updater',
+    # 'resultsdb-updater.resultsdb_pass': 'password',
     'resultsdb-updater.topics': []
 }

--- a/openshift/resultsdb-updater-test-template.yaml
+++ b/openshift/resultsdb-updater-test-template.yaml
@@ -64,7 +64,10 @@ objects:
         'stomp_ssl_key': '/etc/resultsdb/umb-consumer.key.pem',
         'resultsdb-updater.log_level': logging.DEBUG,
         'resultsdb-updater.resultsdb_api_url': '${RESULTSDB_API_URL}',
-        'resultsdb-updater.resultsdb_api_ca': None,
+        # TODO make certificate verification work
+        'resultsdb-updater.resultsdb_api_ca': False,
+        'resultsdb-updater.resultsdb_user': 'resultsdb-updater',
+        'resultsdb-updater.resultsdb_pass': 'password',
         'resultsdb-updater.topics': ["/queue/Consumer.mister.queue.VirtualTopic.Test"],
         'moksha.blocking_mode': True,
       }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+from resultsdbupdater import utils
+
+
+@pytest.mark.parametrize(
+    ('user', 'password', 'url', 'result', 'error'),
+    [
+        # Basic auth correctly configured
+        ('user', 'password', 'https://example.com', ('user', 'password'), None),
+        # Basic auth not configured
+        (None, None, 'http://example.com', None, None),
+        # URL is not HTTPS
+        ('foo', 'bar', 'http://example.com', None, RuntimeError),
+        # User not configured
+        (None, 'bar', 'https://example.com', None, RuntimeError),
+        # Password not configured
+        ('red', None, 'https://example.com', None, RuntimeError),
+    ])
+def test_get_http_auth(user, password, url, result, error):
+    if error:
+        with pytest.raises(error):
+            auth = utils.get_http_auth(user, password, url)
+    else:
+        auth = utils.get_http_auth(user, password, url)
+        assert auth == result


### PR DESCRIPTION
Add configuration keys for user and password.

Use Basic authentication upon creating results,
when the credentials are configured.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>