### PR TITLE
 Run unit tests in Jenkins instead of waiting for Travis

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -4,7 +4,8 @@
 
 set -ex
 
-lasttag="$(git describe --abbrev=0 HEAD)"
+# Handle both lightweight and annotated tags
+lasttag="$(git describe --tags --abbrev=0 HEAD)"
 lastversion="${lasttag##v}"
 revbase="^$lasttag"
 


### PR DESCRIPTION
The waiting for Travis CI groovy code died with an exception I
couldn't solve.

In order to make sure, that unit tests and some linting is run before
building a container image of the application, the unit tests are
going to be executed by the Jenkins job, too.

While Travis is using tox to run these tests, which will pull
dependencies from PyPI, the Jenkins job will make sure that
dependencies are installed from RPMs on a Fedora node.

This way the constellation of app and its dependencies during unit
testing will match the one used for building the container image.