### PR TITLE
Support for container-image CI messages

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -330,6 +330,41 @@ def handle_ci_umb(msg):
                 ('category', msg_body.get('category')),
             ) if value is not None
         }
+    elif item_type == 'container-image':
+        repo = msg_body['artifact']['repository']
+        digest = msg_body['artifact']['digest']
+        item = '{0}@{1}'.format(repo, digest)
+        result_data = {
+            key: value for key, value in (
+                ('item', item),
+
+                ('ci_name', msg_body['ci']['name']),
+                ('ci_team', msg_body['ci']['team']),
+                ('ci_url', msg_body['ci']['url']),
+                ('ci_irc', msg_body['ci'].get('irc')),
+                ('ci_environment', msg_body['ci'].get('environment')),
+                ('ci_email', msg_body['ci']['email']),
+
+                ('log', msg_body['run']['log']),
+                ('rebuild', msg_body['run'].get('rebuild')),
+                ('xunit', msg_body.get('xunit')),
+
+                ('type', item_type),
+                ('repository', msg_body['artifact'].get('repository')),
+                ('digest', msg_body['artifact'].get('digest')),
+                ('format', msg_body['artifact'].get('format')),
+                ('pull_ref', msg_body['artifact'].get('pull_ref')),
+                ('scratch', msg_body['artifact'].get('scratch')),
+                ('nvr', msg_body['artifact'].get('nvr')),
+                ('issuer', msg_body['artifact'].get('issuer')),
+
+                ('system_os', system.get('os')),
+                ('system_provider', system.get('provider')),
+                ('system_architecture', system.get('architecture')),
+
+                ('category', msg_body.get('category')),
+            ) if value is not None
+        }
     elif item_type == 'redhat-module':
         msg_body_ci = msg_body['ci']
 

--- a/tests/fake_messages/container_image_message.json
+++ b/tests/fake_messages/container_image_message.json
@@ -1,0 +1,56 @@
+{
+  "topic": "/topic/VirtualTopic.eng.ci.container-image.test.complete",
+  "headers": {
+    "CI_TYPE": "custom",
+    "expires": "0",
+    "timestamp": "1547722123935",
+    "original-destination": "/topic/VirtualTopic.eng.ci.container-image.test.complete",
+    "destination": "/queue/Consumer.client-datanommer.upshift-dev.VirtualTopic.eng.>",
+    "CI_NAME": "waiverdb-test-stage-waiverdb-dev-integration-test",
+    "persistent": "true",
+    "priority": "4",
+    "message-id": "ID:jenkins-7-dtj6f-40196-1544165803216-163:1:1:1:1",
+    "type": "application/json",
+    "subscription": "/queue/Consumer.client-datanommer.upshift-dev.VirtualTopic.eng.>"
+  },
+  "body": {
+    "msg": {
+      "category": "integration",
+      "status": "passed",
+      "ci": {
+        "name": "C3I Jenkins",
+        "url": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/",
+        "docs": "https://pagure.io/waiverdb/blob/master/f/openshift",
+        "environment": "development",
+        "team": "DevOps",
+        "irc": "#pnt-devops-dev",
+        "email": "pnt-factory2-devel@redhat.com"
+      },
+      "run": {
+        "debug": "",
+        "url": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job/waiverdb-test/job/waiverdb-test-stage-waiverdb-dev-integration-test/104/",
+        "rebuild": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job/waiverdb-test/job/waiverdb-test-stage-waiverdb-dev-integration-test/104//rebuild/parametrized",
+        "log": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job/waiverdb-test/job/waiverdb-test-stage-waiverdb-dev-integration-test/104//console"
+      },
+      "namespace": "waiverdb-test",
+      "system": [
+        {
+          "os": "docker-registry.engineering.redhat.com/factory2/waiverdb-jenkins-slave:latest",
+          "architecture": "x86_64",
+          "provider": "openshift"
+        }
+      ],
+      "artifact": {
+        "nvr": "waiverdb:test",
+        "repository": "factory2/waiverdb",
+        "scratch": true,
+        "type": "container-image",
+        "digest": "sha256:693377241d5bc55af239fdc5183bcc97d7c5c097bebe84097c4388063a3950cc",
+        "issuer": "c3i-jenkins"
+      },
+      "version": "0.1.0",
+      "xunit": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job/waiverdb-test/job/waiverdb-test-stage-waiverdb-dev-integration-test/104//artifacts/junit-functional-tests.xml",
+      "type": "tier1"
+    }
+  }
+}

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -955,3 +955,75 @@ def test_full_consume_redhat_module_success_msg(mock_get_session):
 
     assert all_expected_data == \
         json.loads(mock_requests.post.call_args_list[0][1]['data'])
+
+
+@mock.patch('resultsdbupdater.utils.retry_session')
+def test_container_image_msg(mock_get_session):
+    mock_post_rv = mock.Mock()
+    mock_post_rv.status_code = 201
+    mock_requests = mock.Mock()
+    mock_requests.post.return_value = mock_post_rv
+    mock_get_session.return_value = mock_requests
+    fake_msg_path = path.join(json_dir, 'container_image_message.json')
+    with open(fake_msg_path) as fake_msg_file:
+        fake_msg = json.load(fake_msg_file)
+
+    assert consumer.consume(fake_msg) is True
+    # Verify the post URL
+    assert mock_requests.post.call_args_list[0][0][0] == \
+        'https://resultsdb.domain.local/api/v2.0/results'
+    # Verify the post data
+    assert mock_requests.post.call_count == 1
+    all_expected_data = {
+        "note": "",
+        "ref_url": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job/waiverdb-test"
+                   "/job/waiverdb-test-stage-waiverdb-dev-integration-test/104/",
+        "testcase": {
+            "ref_url": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/",
+            "name": "waiverdb-test.tier1.integration"
+        },
+        "groups": [
+            {
+                "url": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job"
+                       "/waiverdb-test/job/waiverdb-test-stage-waiverdb-dev-integration-test/104/",
+                "uuid": "1bb0a6a5-3287-4321-9dc5-72258a302a37"
+            }
+        ],
+        "outcome": "passed",
+        "data": {
+            "category": "integration",
+            "system_os": "docker-registry.engineering.redhat.com"
+                         "/factory2/waiverdb-jenkins-slave:latest",
+            "log": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job"
+                   "/waiverdb-test/job/waiverdb-test-stage-waiverdb-dev-integration-test"
+                   "/104//console",
+            "repository": "factory2/waiverdb",
+            "issuer": "c3i-jenkins",
+            "ci_environment": "development",
+            "scratch": True,
+            "ci_email": "pnt-factory2-devel@redhat.com",
+            "recipients": [
+
+            ],
+            "ci_name": "C3I Jenkins",
+            "ci_irc": "#pnt-devops-dev",
+            "item": "factory2/waiverdb@sha256:693377241d5bc55af239fdc51"
+                    "83bcc97d7c5c097bebe84097c4388063a3950cc",
+            "system_provider": "openshift",
+            "ci_url": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/",
+            "xunit": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/"
+                     "job/waiverdb-test/job/waiverdb-test"
+                     "-stage-waiverdb-dev-integration-test/104/"
+                     "/artifacts/junit-functional-tests.xml",
+            "system_architecture": "x86_64",
+            "ci_team": "DevOps",
+            "type": "container-image",
+            "rebuild": "https://jenkins-waiverdb-test.cloud.paas.upshift.redhat.com/job"
+                       "/waiverdb-test/job/waiverdb"
+                       "-test-stage-waiverdb-dev-integration-test/104//rebuild/parametrized",
+            "digest": "sha256:693377241d5bc55af239fdc5183bcc97d7c5c097bebe84097c4388063a3950cc",
+            "nvr": "waiverdb:test"
+        }
+    }
+    assert all_expected_data == \
+        json.loads(mock_requests.post.call_args_list[0][1]['data'])


### PR DESCRIPTION
We are looking to test container images in our CI/CD pipelines,
then gate their deployment to production using Factory 2.0 services.

Following up https://github.com/release-engineering/resultsdb-updater/issues/71,
new CI messages types have been defined to support the container gating and promotion workflow.
This PR will allow ResultsDB-Updater to consume `container-image.test.complete` CI messages,
and create corresponding Results objects in ResultsDB.

We haven't fully decided the Result object schema - Still waiting for Greenwave team to check
if all necessary information is included to make a gating decision.