### PR TITLE
Verify namespace in new topic and test case name

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from resultsdbupdater import utils
 
@@ -23,3 +24,64 @@ def test_get_http_auth(user, password, url, result, error):
     else:
         auth = utils.get_http_auth(user, password, url)
         assert auth == result
+
+
+@pytest.mark.parametrize(
+    ('testcase_name', 'namespace'),
+    [
+        ('rhproduct.default.functional', 'rhproduct'),
+        ('', ''),
+    ]
+)
+def test_namespace_from_testcase_name(testcase_name, namespace):
+    assert utils.namespace_from_testcase_name(testcase_name) == namespace
+
+
+@pytest.mark.parametrize(
+    ('topic', 'namespace'),
+    [
+        ('/topic/VirtualTopic.eng.ci.rhproduct.brew-build.test.complete', 'rhproduct'),
+        ('/topic/VirtualTopic.eng.ci.brew-build.test.complete', None),
+    ]
+)
+def test_namespace_from_topic(topic, namespace):
+    assert utils.namespace_from_topic(topic) == namespace
+
+
+@pytest.mark.parametrize(
+    ('topic', 'testcase_name', 'expected_result', 'expected_log'),
+    [
+        (
+            '/topic/VirtualTopic.eng.ci.rhproduct.brew-build.test.complete',
+            'rhproduct.default.functional',
+            True,
+            [],
+        ),
+        (
+            '/topic/VirtualTopic.eng.ci.rhproduct.brew-build.test.complete',
+            'nont-rhproduct.default.functional',
+            False,
+            [
+                'Test case "nont-rhproduct.default.functional" namespace "nont-rhproduct" '
+                'does not match message topic '
+                '"/topic/VirtualTopic.eng.ci.rhproduct.brew-build.test.complete" '
+                'namespace "rhproduct"'
+            ]
+        ),
+        (
+            '/topic/VirtualTopic.eng.ci.brew-build.test.complete',
+            'rhproduct.default.functional',
+            True,
+            [
+                'The message topic "/topic/VirtualTopic.eng.ci.brew-build.test.complete" '
+                'uses old scheme not containing namespace from '
+                'test case name "rhproduct.default.functional"'
+            ]
+        ),
+    ]
+)
+def test_verify_topic_and_testcase_name(
+        topic, testcase_name, expected_result, expected_log, caplog):
+    caplog.set_level(logging.WARNING)
+    assert utils.verify_topic_and_testcase_name(topic, testcase_name) == expected_result
+    assert expected_log == [rec.message for rec in caplog.records]


### PR DESCRIPTION
Prints warning when an old topic without namespace is encountered but
it's still possible to create new test result with such message.

Prints warning when new topic [1] with namespace is encountered and the
new topic doesn't match the one in test case name. No new test results
are created from such messages.

Note: If "namespace" field in the message contains ".", only the
component before the first "." is expected to be in the topic.

New topic schema is:

    /topic/VirtualTopic.eng.ci.<namespace>.<artifact>.<event>.{queued,running,complete,error}

Example of a new topic with "osci" namespace:

    /topic/VirtualTopic.eng.ci.osci.brew-build.test.complete

JIRA: FACTORY-4845
Signed-off-by: Lukas Holecek <hluk@email.cz>