### PR TITLE
Add a timeout to HTTP requests

### DIFF
--- a/fedmsg.d/config.py
+++ b/fedmsg.d/config.py
@@ -21,5 +21,6 @@ config = {
     # Used only for creating results.
     # 'resultsdb-updater.resultsdb_user': 'resultsdb-updater',
     # 'resultsdb-updater.resultsdb_pass': 'password',
-    'resultsdb-updater.topics': []
+    'resultsdb-updater.topics': [],
+    'resultsdb-updater.requests_timeout': 15,
 }

--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -12,6 +12,7 @@ from requests.packages.urllib3.util.retry import Retry
 CONFIG = fedmsg.config.load_config()
 RESULTSDB_API_URL = CONFIG.get('resultsdb-updater.resultsdb_api_url')
 TRUSTED_CA = CONFIG.get('resultsdb-updater.resultsdb_api_ca')
+TIMEOUT = CONFIG.get('resultsdb-updater.requests_timeout', 15)
 
 LOGGER = logging.getLogger('CIConsumer')
 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -110,6 +111,7 @@ def create_result(session, testcase, outcome, ref_url, data, groups=None,
             'data': data}),
         headers={'content-type': 'application/json'},
         auth=RESULTSDB_AUTH,
+        timeout=TIMEOUT,
         verify=TRUSTED_CA)
     if post_req.status_code == 201:
         return True
@@ -123,6 +125,7 @@ def create_result(session, testcase, outcome, ref_url, data, groups=None,
 def get_first_group(session, description):
     get_req = session.get(
         '{0}/groups?description={1}'.format(RESULTSDB_API_URL, description),
+        timeout=TIMEOUT,
         verify=TRUSTED_CA
     )
     if get_req.status_code == 200:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -124,6 +124,7 @@ def test_full_consume_overall_rpmdiff_msg(mock_get_session):
     mock_requests.get.assert_called_once_with(
         ('https://resultsdb.domain.local/api/v2.0/groups?description='
          'https://domain.local/run/12345'),
+        timeout=15,
         verify=None
     )
     # Verify the post URL
@@ -178,6 +179,7 @@ def test_full_consume_rpmdiff_msg(mock_get_session):
     mock_requests.get.assert_called_once_with(
         ('https://resultsdb.domain.local/api/v2.0/groups?description='
          'https://domain.local/run/12345'),
+        timeout=15,
         verify=None
     )
     # Verify the post URL
@@ -300,6 +302,7 @@ def test_full_consume_covscan_msg(mock_get_session):
     mock_requests.get.assert_called_once_with(
         ('https://resultsdb.domain.local/api/v2.0/groups?description='
          'http://domain.local/covscanhub/task/64208/log/added.html'),
+        timeout=15,
         verify=None
     )
     # Verify the post URL


### PR DESCRIPTION
This will prevent the service from hanging due to a failed connection.