### PR TITLE
Avoid propagating frequent exception from consumer

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1031,3 +1031,8 @@ def test_full_consume_post_timeout(mock_requests):
 
     with pytest.raises(requests.exceptions.Timeout):
         consumer.consume(fake_msg)
+
+
+def test_consume_no_exception_on_bad_message(caplog):
+    consumer.consume({})
+    assert 'Failed to process message' in caplog.text


### PR DESCRIPTION
If an exception is propagated from consumer, the same message could be
delivered again later. But if the exception was thrown, for example,
because the message format is incorrect, consecutive run would probably
result in the same exception and this would only delay processing other
messages.

So for common exception, like KeyError or TypeError (but unlike
HTTPError), the consumer will only log the exception and stop it from
propagating.

JIRA: FACTORY-5345
Signed-off-by: Lukas Holecek <hluk@email.cz>