### PR TITLE
Use "contact" field and fall back to "ci"

### DIFF
--- a/resultsdbupdater/consumer.py
+++ b/resultsdbupdater/consumer.py
@@ -40,7 +40,7 @@ class CIConsumer(fedmsg.consumers.FedmsgConsumer):
 
         # Next, detect if the message bears the primary format we support.
         # The "FACTORY 2.0 CI UMB messages"
-        # https://docs.google.com/document/d/16L5odC-B4L6iwb9dp8Ry0Xk5Sc49h9KvTHrG86fdfQM/edit
+        # See: https://pagure.io/fedora-ci/messages
         ci_umb_keys = set(['run', 'artifact'])
         contact_umb_keys = set(['ci', 'contact'])
         if actual_keys.issuperset(ci_umb_keys) and not actual_keys.isdisjoint(contact_umb_keys):

--- a/resultsdbupdater/consumer.py
+++ b/resultsdbupdater/consumer.py
@@ -41,8 +41,9 @@ class CIConsumer(fedmsg.consumers.FedmsgConsumer):
         # Next, detect if the message bears the primary format we support.
         # The "FACTORY 2.0 CI UMB messages"
         # https://docs.google.com/document/d/16L5odC-B4L6iwb9dp8Ry0Xk5Sc49h9KvTHrG86fdfQM/edit
-        ci_umb_keys = set(['ci', 'run', 'artifact'])
-        if actual_keys.issuperset(ci_umb_keys):
+        ci_umb_keys = set(['run', 'artifact'])
+        contact_umb_keys = set(['ci', 'contact'])
+        if actual_keys.issuperset(ci_umb_keys) and not actual_keys.isdisjoint(contact_umb_keys):
             self.log_msg(msg)
             utils.handle_ci_umb(msg)
             return

--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -50,6 +50,12 @@ class RequiredFieldException(Exception):
     pass
 
 
+def get_contact(msg_body):
+    if semantic_version.match('<0.2.1', msg_body['version']):
+        return msg_body['ci']
+    return msg_body['contact']
+
+
 def get_http_auth(user, password, url):
     """Return an auth tuple to be used with requests
 
@@ -422,6 +428,8 @@ def handle_ci_umb(msg):
     if isinstance(system, list):
         system = system[0] if system else {}
 
+    contact = get_contact(msg_body)
+
     if item_type == 'productmd-compose':
         architecture = system['architecture']
         variant = system.get('variant')
@@ -432,11 +440,11 @@ def handle_ci_umb(msg):
             key: value for key, value in (
                 ('item', item),
 
-                ('ci_name', msg_body['ci']['name']),
-                ('ci_team', msg_body['ci']['team']),
-                ('ci_url', msg_body['ci'].get('url', 'not available')),
-                ('ci_irc', msg_body['ci'].get('irc', 'not available')),
-                ('ci_email', msg_body['ci']['email']),
+                ('ci_name', contact['name']),
+                ('ci_team', contact['team']),
+                ('ci_url', contact.get('url', 'not available')),
+                ('ci_irc', contact.get('irc', 'not available')),
+                ('ci_email', contact['email']),
 
                 ('log', msg_body['run']['log']),
 
@@ -459,11 +467,11 @@ def handle_ci_umb(msg):
             key: value for key, value in (
                 ('item', item),
 
-                ('ci_name', msg_body['ci']['name']),
-                ('ci_team', msg_body['ci']['team']),
-                ('ci_url', msg_body['ci'].get('url', 'not available')),
-                ('ci_irc', msg_body['ci'].get('irc', 'not available')),
-                ('ci_email', msg_body['ci']['email']),
+                ('ci_name', contact['name']),
+                ('ci_team', contact['team']),
+                ('ci_url', contact.get('url', 'not available')),
+                ('ci_irc', contact.get('irc', 'not available')),
+                ('ci_email', contact['email']),
 
                 ('log', msg_body['run']['log']),
 
@@ -483,11 +491,11 @@ def handle_ci_umb(msg):
             key: value for key, value in (
                 ('item', item),
 
-                ('ci_name', msg_body['ci']['name']),
-                ('ci_team', msg_body['ci']['team']),
-                ('ci_url', msg_body['ci'].get('url', 'not available')),
-                ('ci_irc', msg_body['ci'].get('irc', 'not available')),
-                ('ci_email', msg_body['ci']['email']),
+                ('ci_name', contact['name']),
+                ('ci_team', contact['team']),
+                ('ci_url', contact.get('url', 'not available')),
+                ('ci_irc', contact.get('irc', 'not available')),
+                ('ci_email', contact['email']),
 
                 ('log', msg_body['run']['log']),
                 ('rebuild', msg_body['run'].get('rebuild')),
@@ -511,8 +519,6 @@ def handle_ci_umb(msg):
         }
 
     elif item_type == 'redhat-module':
-        msg_body_ci = msg_body['ci']
-
         # The pagure.io/messages spec defines the NSVC delimited with ':' and the stream name can
         # contain '-', which MBS changes to '_' when importing to koji.
         # See https://github.com/release-engineering/resultsdb-updater/pull/73
@@ -543,15 +549,14 @@ def handle_ci_umb(msg):
             'log': msg_body['run']['log'],
             'system_os': system.get('os'),
             'system_provider': system.get('provider'),
-            'ci_name': msg_body_ci.get('name'),
-            'ci_url': msg_body_ci.get('url', 'not available'),
-            'ci_team': msg_body_ci.get('team'),
-            'ci_irc': msg_body_ci.get('irc', 'not available'),
-            'ci_email': msg_body_ci.get('email'),
+            'ci_name': contact.get('name'),
+            'ci_url': contact.get('url', 'not available'),
+            'ci_team': contact.get('team'),
+            'ci_irc': contact.get('irc', 'not available'),
+            'ci_email': contact.get('email'),
         }
     # used as a default
     elif item_type == 'brew-build':
-        msg_body_ci = msg_body['ci']
         item = msg_body['artifact']['nvr']
         component = msg_body['artifact']['component']
         scratch = msg_body['artifact'].get('scratch', '')
@@ -578,11 +583,11 @@ def handle_ci_umb(msg):
             'log': msg_body['run']['log'],  # required
             'system_os': system.get('os'),
             'system_provider': system.get('provider'),
-            'ci_name': msg_body_ci.get('name'),
-            'ci_url': msg_body_ci.get('url', 'not available'),
-            'ci_team': msg_body_ci.get('team'),
-            'ci_irc': msg_body_ci.get('irc', 'not available'),
-            'ci_email': msg_body_ci.get('email'),
+            'ci_name': contact.get('name'),
+            'ci_url': contact.get('url', 'not available'),
+            'ci_team': contact.get('team'),
+            'ci_irc': contact.get('irc', 'not available'),
+            'ci_email': contact.get('email'),
         }
 
     # an unknown artifact type

--- a/tests/fake_messages/fedora-ci-message-brew-build.test.complete-2.0.0.json
+++ b/tests/fake_messages/fedora-ci-message-brew-build.test.complete-2.0.0.json
@@ -1,10 +1,11 @@
 {
   "body": {
     "msg": {
-      "ci": {
+      "contact": {
         "team": "team",
         "irc": "#team",
         "email": "team-list@redhat.com",
+        "docs": "https://somewhere.com/user-documentation",
         "name": "TEAM"
       },
       "run": {
@@ -30,12 +31,12 @@
         "id": 18400235,
         "issuer": "batman"
       },
-      "system": {
+      "system": [{
         "provider": "downshaft",
         "os": "RHEL-8.0.0",
         "architecture": "x86_64",
         "label": "downstream-rhel-pipeline"
-      },
+      }],
       "thread_id": "2b2b27d4-de01-49ab-bbc3-cd30dd5286d2",
       "version": "0.2.1",
       "test": {


### PR DESCRIPTION
Field "contact" should be used instead of "ci" in newer message versions
(>=0.2.1).

JIRA: FACTORY-5410
Signed-off-by: Lukas Holecek <hluk@email.cz>