### PR TITLE
Avoid sending NACKs

### DIFF
--- a/resultsdbupdater/consumer.py
+++ b/resultsdbupdater/consumer.py
@@ -86,3 +86,9 @@ class CIConsumer(fedmsg.consumers.FedmsgConsumer):
             # Disallow propagating exceptions which would be raised again on
             # message redelivery.
             utils.LOGGER.exception('Failed to process message')
+        except Exception:
+            # Disallow propagating any other exception, otherwise NACK is sent
+            # and the message is scheduled to be received later. But it seems
+            # these messages can be only received by other consumer (or after
+            # restart) otherwise the messages can block the queue completely.
+            utils.LOGGER.exception('Unexpected exception')


### PR DESCRIPTION
Avoid sending NACKs

Disallows propagating any exception from consumer, otherwise NACK is
sent and the message is scheduled to be received later. But it seems
these messages can be only received by other consumer (or after restart)
otherwise the messages can block the queue completely.

---

Revert removing request retry logic

Since we cannot rely on NACKs to redeliver messages (message would need
to go to a different consumer) we must handle request retries manually.
