### PR TITLE
Add support for ERROR outcome

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -176,10 +176,10 @@ def _test_result_outcome(topic, outcome):
 
     Some systems generate outcomes that don't match spec.
 
-    Test outcome is FAILED for messages with "*.error" topic.
+    Test outcome is ERROR for messages with "*.error" topic.
     """
     if topic.endswith('.error'):
-        return 'FAILED'
+        return 'ERROR'
     elif topic.endswith('.queued'):
         return 'QUEUED'
     elif topic.endswith('.running'):
@@ -445,6 +445,14 @@ def handle_ci_umb(msg):
     except exceptions.MissingTopicError as e:
         # Old topics are allowed for now.
         msg.log.warning(e)
+
+    if outcome == 'ERROR':
+        error_reason = msg.get('error', 'reason')
+        result_data['error_reason'] = error_reason
+
+        issue_url = msg.get('error', 'issue_url', default=None)
+        if issue_url:
+            result_data['issue_url'] = issue_url
 
     create_result(testcase, outcome, test_run_url, result_data, groups)
 

--- a/tests/fake_messages/pipeline_failure_message.json
+++ b/tests/fake_messages/pipeline_failure_message.json
@@ -46,7 +46,9 @@
         "id": "15665813",
         "issuer": null
       },
-      "reason": "unknown execution error",
+      "error": {
+          "reason": "unknown execution error"
+      },
       "type": "pipeline",
       "namespace": "contra",
       "version": "0.1.0"

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -328,6 +328,7 @@ def test_full_consume_pipeline_failure_msg(mock_session):
             'type': 'brew-build_scratch',
 
             'component': 'tigervnc',
+            'error_reason': 'unknown execution error',
             'brew_task_id': '15665813',
             'category': 'functional',
             'scratch': True,
@@ -352,7 +353,7 @@ def test_full_consume_pipeline_failure_msg(mock_session):
             'uuid': '1bb0a6a5-3287-4321-9dc5-72258a302a37'
         }],
         'note': '',
-        'outcome': 'FAILED',
+        'outcome': 'ERROR',
         'ref_url': 'https://domain.redhat.com/job/downstream-rhel9000-build-pipeline/34/',
         'testcase': {
             'name': 'contra.pipeline.functional',


### PR DESCRIPTION
The result data contains "error_reason" and "issue_url".

JIRA: FACTORY-5181
Signed-off-by: Lukas Holecek <hluk@email.cz>