### PR TITLE
Add support for product-build test messages

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -319,6 +319,25 @@ def handle_ci_umb(msg):
             ) if value is not None
         }
 
+    elif item_type == 'product-build':
+        product = msg.get('artifact', 'name')
+        version = msg.get('artifact', 'version')
+        release = msg.get('artifact', 'release')
+        item = '{0}-{1}-{2}'.format(product, version, release)
+        result_data = {
+            key: value for key, value in (
+                ('item', item),
+                ('product', product),
+                ('version', version),
+                ('release', release),
+                ('artifacts', msg.get('artifact', 'artifacts', default=[])),
+                ('log', msg.get('run', 'log')),
+                ('type', item_type),
+                ('system_architecture', msg.system('architecture')),
+                ('category', msg.result.category),
+            ) if value is not None
+        }
+
     elif item_type == 'component-version':
         component = msg.get('artifact', 'component')
         version = msg.get('artifact', 'version')

--- a/tests/fake_messages/product_build_empty_artifacts.json
+++ b/tests/fake_messages/product_build_empty_artifacts.json
@@ -1,0 +1,52 @@
+{
+  "topic": "/topic/VirtualTopic.eng.ci.cnv.product-build.test.complete",
+  "msg_id": "ID:jenkins-1-tkzs8-42898-1573394681712-53:1:1:1:1",
+  "timestamp": 1573398038.0,
+  "headers": {
+    "message-id": "ID:jenkins-1-tkzs8-46019-1573641290637-11:1:1:1:1"
+  },
+  "body": {
+    "msg": {
+      "artifact": {
+        "artifacts": [],
+        "id": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "name": "CNV",
+        "release": "20191023.57",
+        "type": "product-build",
+        "version": "1.4.0"
+      },
+      "contact": {
+        "docs": "https://docs.engineering.redhat.com/display/CPROD/Continuous-Productization-as-a-Service",
+        "email": "cpaas-ops@redhat.com",
+        "name": "CPaaS",
+        "team": "CPaaS",
+        "url": "https://jenkins-cnv14.192.168.42.176.nip.io/"
+      },
+      "generated_at": "2019-11-13T13:27:05.262Z",
+      "pipeline": {
+        "id": "cnv-qe-e3b0c44",
+        "name": "cnv-qe-pipeline"
+      },
+      "run": {
+        "log": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/console",
+        "log_raw": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/consoleText",
+        "rebuild": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/rebuild",
+        "url": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/"
+      },
+      "system": [
+        {
+          "architecture": "x86_64",
+          "provider": "custom",
+          "os": "openshift"
+        }
+      ],
+      "test": {
+        "type": "smoke-test",
+        "category": "validation",
+        "result": "passed",
+        "namespace": "cnv.product-build"
+      },
+      "version": "0.2.4"
+    }
+  }
+}

--- a/tests/fake_messages/product_build_with_artifacts.json
+++ b/tests/fake_messages/product_build_with_artifacts.json
@@ -1,0 +1,65 @@
+{
+  "topic": "/topic/VirtualTopic.eng.ci.cnv.product-build.test.complete",
+  "msg_id": "ID:jenkins-1-tkzs8-42898-1573394681712-53:1:1:1:1",
+  "timestamp": 1573398038.0,
+  "headers": {
+    "message-id": "ID:jenkins-1-tkzs8-46019-1573641290637-11:1:1:1:1"
+  },
+  "body": {
+    "msg": {
+      "artifact": {
+        "artifacts": [
+          {
+            "type": "redhat-container-image",
+            "id": "994547",
+            "component": "CNV",
+            "name": "virt-cdi-controller-cpaas-mvp-container",
+            "full_name": "registry-proxy.engineering.redhat.com/rh-osbs/cnv-tech-preview-virt-cdi-controller-cpaas-mvp:v1.4.0-27",
+            "nvr": "virt-cdi-controller-cpaas-mvp-container-v1.4.0-27",
+            "digest": "sha256:f2b8d884775ca10e32ea01aa43ce8e9fc06a53101f10386bd8557cfa42536729",
+            "issuer": "contra/pipeline",
+            "source": "git://pkgs.devel.redhat.com/containers/virt-cdi-controller-cpaas-mvp#628e4d697b0143aec599343b02f0dc79c0b80175",
+            "scratch": false
+          }
+        ],
+        "id": "sha256:b870b5ae5569925e9ab241e68560e300e59c7a7763d4e728c70ab466ce8b6f31",
+        "name": "CNV",
+        "release": "20191023.57",
+        "type": "product-build",
+        "version": "1.4.0"
+      },
+      "contact": {
+        "docs": "https://docs.engineering.redhat.com/display/CPROD/Continuous-Productization-as-a-Service",
+        "email": "cpaas-ops@redhat.com",
+        "name": "CPaaS",
+        "team": "CPaaS",
+        "url": "https://jenkins-cnv14.192.168.42.176.nip.io/"
+      },
+      "generated_at": "2019-11-13T13:27:05.262Z",
+      "pipeline": {
+        "id": "cnv-qe-e3b0c44",
+        "name": "cnv-qe-pipeline"
+      },
+      "run": {
+        "log": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/console",
+        "log_raw": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/consoleText",
+        "rebuild": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/rebuild",
+        "url": "https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/"
+      },
+      "system": [
+        {
+          "architecture": "x86_64",
+          "provider": "custom",
+          "os": "openshift"
+        }
+      ],
+      "test": {
+        "type": "smoke-test",
+        "category": "validation",
+        "result": "passed",
+        "namespace": "cnv.product-build"
+      },
+      "version": "0.2.4"
+    }
+  }
+}

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -528,6 +528,112 @@ def test_full_consume_compose_msg(mock_session):
     assert expected_data == actual_data, actual_data
 
 
+def test_product_build_with_artifacts(mock_session):
+    fake_msg = get_fake_msg('product_build_with_artifacts')
+    consumer.consume(fake_msg)
+    # Verify the URLs called
+    assert mock_session.post.call_args_list[0][0][0] == \
+        'https://resultsdb.domain.local/api/v2.0/results'
+    # Verify the post data
+    assert mock_session.post.call_count == 1
+    url = 'https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/'
+    digest = 'sha256:f2b8d884775ca10e32ea01aa43ce8e9fc06a53101f10386bd8557cfa42536729'
+    full_name = 'registry-proxy.engineering.redhat.com/rh-osbs/cnv-tech-preview-virt-cdi-controller-cpaas-mvp:v1.4.0-27'    # noqa: E501
+    source_url = 'git://pkgs.devel.redhat.com/containers/virt-cdi-controller-cpaas-mvp#628e4d697b0143aec599343b02f0dc79c0b80175'    # noqa: E501
+    expected_data = {
+        'data': {
+            'artifacts': [
+                {
+                    'component': 'CNV',
+                    'digest': digest,
+                    'full_name': full_name,
+                    'id': '994547',
+                    'issuer': 'contra/pipeline',
+                    'name': 'virt-cdi-controller-cpaas-mvp-container',
+                    'nvr': 'virt-cdi-controller-cpaas-mvp-container-v1.4.0-27',
+                    'scratch': False,
+                    'source': source_url,
+                    'type': 'redhat-container-image'
+                }
+            ],
+            'category': 'validation',
+            'ci_email': 'cpaas-ops@redhat.com',
+            'ci_irc': 'not available',
+            'ci_name': 'CPaaS',
+            'ci_team': 'CPaaS',
+            'ci_url': 'https://jenkins-cnv14.192.168.42.176.nip.io/',
+            'item': 'CNV-1.4.0-20191023.57',
+            'log': url + 'console',
+            'product': 'CNV',
+            'recipients': [],
+            'release': '20191023.57',
+            'system_architecture': 'x86_64',
+            'type': 'product-build',
+            'version': '1.4.0'
+        },
+        'groups': [
+            {
+                'url': url,
+                'uuid': '1bb0a6a5-3287-4321-9dc5-72258a302a37'
+            }
+        ],
+        'note': '',
+        'outcome': 'PASSED',
+        'ref_url': url,
+        'testcase': {
+            'name': 'cnv.product-build.smoke-test.validation',
+            'ref_url': url
+        }
+    }
+    assert expected_data == \
+        json.loads(mock_session.post.call_args_list[0][1]['data'])
+
+
+def test_product_build_empty_artifacts(mock_session):
+    fake_msg = get_fake_msg('product_build_empty_artifacts')
+    consumer.consume(fake_msg)
+    # Verify the URLs called
+    assert mock_session.post.call_args_list[0][0][0] == \
+        'https://resultsdb.domain.local/api/v2.0/results'
+    # Verify the post data
+    assert mock_session.post.call_count == 1
+    url = 'https://jenkins-cnv14.192.168.42.176.nip.io/job/send-product-build-message-resultdb/3/'
+    expected_data = {
+        'data': {
+            'artifacts': [],
+            'category': 'validation',
+            'ci_email': 'cpaas-ops@redhat.com',
+            'ci_irc': 'not available',
+            'ci_name': 'CPaaS',
+            'ci_team': 'CPaaS',
+            'ci_url': 'https://jenkins-cnv14.192.168.42.176.nip.io/',
+            'item': 'CNV-1.4.0-20191023.57',
+            'log': url + 'console',
+            'product': 'CNV',
+            'recipients': [],
+            'release': '20191023.57',
+            'system_architecture': 'x86_64',
+            'type': 'product-build',
+            'version': '1.4.0'
+        },
+        'groups': [
+            {
+                'url': url,
+                'uuid': '1bb0a6a5-3287-4321-9dc5-72258a302a37'
+            }
+        ],
+        'note': '',
+        'outcome': 'PASSED',
+        'ref_url': url,
+        'testcase': {
+            'name': 'cnv.product-build.smoke-test.validation',
+            'ref_url': url
+        }
+    }
+    assert expected_data == \
+        json.loads(mock_session.post.call_args_list[0][1]['data'])
+
+
 def test_queued_outcome_msg(mock_session):
     fake_msg = get_fake_msg('platformci_queued_message')
     consumer.consume(fake_msg)


### PR DESCRIPTION
In CPaaS we build products. To trigger QE automation and to implement
gating we use messages following the product-build message format.
As part of the gating flow, we want results of QE tests to be stored
into ResultsDB.