### PR TITLE
Limit size of error_reason

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -491,7 +491,7 @@ def handle_ci_umb(msg):
         msg.log.warning(e)
 
     if outcome == 'ERROR':
-        result_data['error_reason'] = msg.error_reason
+        result_data['error_reason'] = msg.error_reason[:256]
 
         issue_url = msg.get('error', 'issue_url', default=None)
         if issue_url:


### PR DESCRIPTION
Fixes issue with stuck request to ResultsDB.

TODO:
- Why the request did not timeout?
- Limit size of characters in for other fields in POST request.

JIRA: FACTORY-5775
Signed-off-by: Lukas Holecek <hluk@email.cz>