### PR TITLE
Update Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
       env: TOXENV=py27
     - python: 3.6
       env: TOXENV=py36
+     - python: 3.7
+      env: TOXENV=py37
     - env: TOXENV=flake8
 install:
   - pip install tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:31
 LABEL \
     name="ResultsDB-Updater application" \
     vendor="ResultsDB-Updater developers" \
@@ -10,8 +10,9 @@ results on the CI message bus and updates ResultsDB in a standard format." \
 
 RUN dnf install -y \
         fedmsg \
-        python-requests \
-        python2-semantic_version \
+        python3-pip \
+        python3-requests \
+        python3-semantic_version \
     && dnf clean -y all
 
 COPY ["setup.py", "requirements.txt", "/src/resultsdb-updater/"]

--- a/README.md
+++ b/README.md
@@ -33,19 +33,13 @@ fedmsg-hub
 
 ### Running the service in a container
 
-Building the container image requires the ResultsDB-Updater rpm to be provided
-as a build argument:
+To build a container image with ResultsDB-Updater run:
 
 ```bash
-$ docker build -f openshift/Dockerfile \
-               --tag <IMAGE_TAG> \
-               --build-arg resultsdb_updater_rpm=<RESULTSDB_UPDATER_RPM> ./
+$ podman build --tag <IMAGE_TAG> .
 ```
 
 `IMAGE_TAG` is the tag to be applied on the image built.
-
-`RESULTSDB_UPDATER_RPM` is either the URL of the ResultsDB-Updater rpm, or the
-relative path of that rpm *within* the build context.
 
 There are two volumes expected to be mounted when ResultsDB-Updater containers
 are started:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8, py27, py36
+envlist = flake8, py27, py36, py37
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
The Dockerfile and the instructions for building the container image were out of date.

This updates the base image to Fedora 31, makes sure the code is working with Python 3.7 (the default version in Fedora 31) and updates the instructions for building the container image.