### PR TITLE
Fix fedmsg configuration URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ are started:
 1. A volume mounted at `/etc/fedmsg.d` with any `*.py` file holding fedmsg and
    ResultsDB-Updater configuration. For an example see `fedmsg.d/config.py` or
    the documentation on [how to configure
-   fedmsg](http://www.fedmsg.com/en/latest/configuration/#).
+   fedmsg](https://fedmsg.readthedocs.io/en/stable/configuration/).
 
 2. A volume mounted at `/etc/resultsdb` holding the client certificate and
    private key files, to be used with STOMP when authenticating with the


### PR DESCRIPTION
The federated-message-bus configuration hyper-link was obsolete, so it needs to be changed to a recent one.