### PR TITLE
Refuse to store large texts in result

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,3 +61,18 @@ def test_verify_topic_and_testcase_name_with_non_eng_topic():
     testcase = 'rhproduct.default.functional'
     with pytest.raises(exceptions.MissingTopicError):
         utils.verify_topic_and_testcase_name(topic, testcase)
+
+
+def test_value_too_large():
+    """
+    Large values cannot be stored in ResultsDB in a DB index.
+
+    Storing values too big for DB index also caused the POST request to get
+    stuck for some reason.
+
+    JIRA: FACTORY-5780
+    """
+    expected_error = 'Value for key "reason" is too large (maximum size is 8192)'
+    with pytest.raises(exceptions.InvalidMessageError) as excinfo:
+        utils.validate_data({'reason': '.' * 8193})
+    assert str(excinfo.value) == expected_error


### PR DESCRIPTION
Even thought size for result data are not limited in database schema,
Postgresql index has a size limited ("Values larger than 1/3 of a buffer
page cannot be indexed").

Storing values too big for DB index also caused the POST request to get
stuck for some reason.

The fix is simply to refuse storing values larger than some 8192.

JIRA: FACTORY-5780

Signed-off-by: Lukas Holecek <hluk@email.cz>