### PR TITLE
Store brew-build-group builds as separate results in same group

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1106,56 +1106,102 @@ def test_fedora_ci_message_brew_build_test_complete_version_2(mock_session):
 def test_fedora_ci_message_brew_build_group_test_complete(mock_session):
     fake_msg = get_fake_msg('brew-build-group.test.complete')
     consumer.consume(fake_msg)
-    assert mock_session.post.call_count == 1
-    all_expected_data = {
-        'data': {
-            'item': 'sha256:acbfb0c61199e5a05f07ee4ec2cdf7fb93376513b82cb5ad444e4d94e4258785',
-            'type': 'brew-build-group',
-            'repository': 'https://some.url/repo',
-            'category': 'functional',
-            'builds': [{
-                'type': 'brew-build',
-                'id': 14546276,
-                'issuer': 'alice',
-                'component': 'libselinux',
-                'nvr': 'libselinux-2.8-6.el7.x86_64',
-                'scratch': False,
-                'source': 'git+https://src.fedoraproject.org/rpms/libselinux.git?#5e0ae23a'
-            }, {
-                'type': 'brew-build',
-                'id': 14546277,
-                'issuer': 'bob',
-                'component': 'libsepol',
-                'nvr': 'libsepol-2.8-3.el7.x86_64',
-                'scratch': False,
-                'source': 'git+https://src.fedoraproject.org/rpms/libsepol.git?#5e0ae23a'
-            }],
-            'rebuild': 'https://somewhere.com/job/ci-openstack/4794/rebuild/parametrized',
-            'log': 'https://somewhere.com/job/ci-openstack/4794/console',
-            'system_os': 'Fedora-Cloud-Base-28',
-            'system_provider': 'openstack',
-            'ci_name': 'BaseOS CI',
-            'ci_url': 'https://somewhere.com',
-            'ci_team': 'BaseOS',
-            'ci_irc': '#baseosci',
-            'ci_email': 'baseos-ci@somewhere.com',
-            'recipients': ['claire', 'daniel'],
-        },
-        'groups': [{
-            'url': 'https://somewhere.com/job/ci-openstack/4794',
-            'uuid': '1bb0a6a5-3287-4321-9dc5-72258a302a37'
-        }],
-        'outcome': 'FAILED',
-        'ref_url': 'https://somewhere.com/job/ci-openstack/4794',
-        'testcase': {
-            'name': 'baseos-qe.baseos-ci.tier1.functional',
-            'ref_url': 'https://somewhere.com/job/ci-openstack/4794',
-        },
-        'note': 'Some notes.'
+
+    brew_build_group = (
+        'sha256:acbfb0c61199e5a05f07ee4ec2cdf7fb93376513b82cb5ad444e4d94e4258785')
+    groups = [{
+        'url': 'https://somewhere.com/job/ci-openstack/4794',
+        'uuid': '1bb0a6a5-3287-4321-9dc5-72258a302a37'
+    }]
+    testcase = {
+        'name': 'baseos-qe.baseos-ci.tier1.functional',
+        'ref_url': 'https://somewhere.com/job/ci-openstack/4794'
     }
 
-    assert all_expected_data == \
-        json.loads(mock_session.post.call_args_list[0][1]['data'])
+    expected_data = [
+        {
+            'data': {
+                'baseline': None,
+                'brew_build_group': brew_build_group,
+                'ci_email': 'baseos-ci@somewhere.com',
+                'ci_irc': '#baseosci',
+                'ci_name': 'BaseOS CI',
+                'ci_team': 'BaseOS',
+                'ci_url': 'https://somewhere.com',
+                'component': 'libselinux',
+                'dependencies': [],
+                'issuer': 'alice',
+                'item': 14546276,
+                'nvr': 'libselinux-2.8-6.el7.x86_64',
+                'recipients': ['claire',
+                               'daniel'],
+                'scratch': False,
+                'source': 'git+https://src.fedoraproject.org/rpms/libselinux.git?#5e0ae23a',
+                'type': 'brew-build'
+            },
+            'note': 'Some notes.',
+            'outcome': 'FAILED',
+            'ref_url': 'https://somewhere.com/job/ci-openstack/4794',
+            'groups': groups,
+            'testcase': testcase
+        },
+        {
+            'data': {
+                'baseline': None,
+                'brew_build_group': brew_build_group,
+                'ci_email': 'baseos-ci@somewhere.com',
+                'ci_irc': '#baseosci',
+                'ci_name': 'BaseOS CI',
+                'ci_team': 'BaseOS',
+                'ci_url': 'https://somewhere.com',
+                'component': 'libsepol',
+                'dependencies': [],
+                'issuer': 'bob',
+                'item': 14546277,
+                'nvr': 'libsepol-2.8-3.el7.x86_64',
+                'recipients': ['claire',
+                               'daniel'],
+                'scratch': False,
+                'source': 'git+https://src.fedoraproject.org/rpms/libsepol.git?#5e0ae23a',
+                'type': 'brew-build'
+            },
+            'note': 'Some notes.',
+            'outcome': 'FAILED',
+            'ref_url': 'https://somewhere.com/job/ci-openstack/4794',
+            'groups': groups,
+            'testcase': testcase
+        },
+        {
+            'data': {
+                'item': brew_build_group,
+                'type': 'brew-build-group',
+                'repository': 'https://some.url/repo',
+                'category': 'functional',
+                'rebuild': 'https://somewhere.com/job/ci-openstack/4794/rebuild/parametrized',
+                'log': 'https://somewhere.com/job/ci-openstack/4794/console',
+                'system_os': 'Fedora-Cloud-Base-28',
+                'system_provider': 'openstack',
+                'ci_name': 'BaseOS CI',
+                'ci_url': 'https://somewhere.com',
+                'ci_team': 'BaseOS',
+                'ci_irc': '#baseosci',
+                'ci_email': 'baseos-ci@somewhere.com',
+                'recipients': ['claire', 'daniel'],
+            },
+            'outcome': 'FAILED',
+            'ref_url': 'https://somewhere.com/job/ci-openstack/4794',
+            'note': 'Some notes.',
+            'groups': groups,
+            'testcase': testcase
+        },
+    ]
+
+    actual_data = [
+        json.loads(args[1]['data'])
+        for args in mock_session.post.call_args_list
+    ]
+
+    assert expected_data == actual_data
 
 
 def test_validate_throws_only_runtime_warning(mock_session, caplog):


### PR DESCRIPTION
Fixes storing builds in the group result - ResultsDB would store items
in the "builds" list as strings (not JSON, just stringified Python
dicts).

Signed-off-by: Lukas Holecek <hluk@email.cz>