### PR TITLE
Make "name" field optional for "redhat-container-image" results

### DIFF
--- a/resultsdbupdater/utils.py
+++ b/resultsdbupdater/utils.py
@@ -434,7 +434,7 @@ def handle_ci_umb(msg):
             'tag': msg.get('artifact', 'tag', default=None),
             'issuer': msg.get('artifact', 'issuer'),
             'component': msg.get('artifact', 'component'),
-            'name': msg.get('artifact', 'name'),
+            'name': msg.get('artifact', 'name', default=None),
             'namespace': msg.get('artifact', 'namespace'),
             'scratch': msg.get('artifact', 'scratch'),
             'nvr': msg.get('artifact', 'nvr'),


### PR DESCRIPTION
This follows the message schema instead of failing to process valid
messages with:

    Invalid message rejected: Missing field "artifact.name"

JIRA: RHELWF-2700