### PR TITLE
Bump base image to fedora:33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM registry.fedoraproject.org/fedora:33
 LABEL \
     name="ResultsDB-Updater application" \
     vendor="ResultsDB-Updater developers" \


### PR DESCRIPTION
Also uses Fedora image registry to avoid "toomanyrequests" error from
Dockerhub.