### PR TITLE
Add support for private test cases

### DIFF
--- a/fedmsg.d/config.py
+++ b/fedmsg.d/config.py
@@ -24,4 +24,7 @@ config = {
     # 'resultsdb-updater.resultsdb_pass': 'password',
     'resultsdb-updater.topics': [],
     'resultsdb-updater.requests_timeout': 15,
+    'resultsdb-updater.private_testcase_publisher_map': (
+        ('prodsec.*', 'msg-producer-prodsec'),
+    ),
 }

--- a/resultsdbupdater/config.py
+++ b/resultsdbupdater/config.py
@@ -53,3 +53,8 @@ RESULTSDB_AUTH = get_http_auth(
     CONFIG.get('resultsdb-updater.resultsdb_user'),
     CONFIG.get('resultsdb-updater.resultsdb_pass'),
     RESULTSDB_API_URL)
+
+# Private test case (glob pattern) always require to match JMSXUserID in
+# messages.
+PRIVATE_TESTCASE_PUBLISHER_MAP = CONFIG.get(
+    'resultsdb-updater.private_testcase_publisher_map', ())

--- a/resultsdbupdater/exceptions.py
+++ b/resultsdbupdater/exceptions.py
@@ -36,6 +36,18 @@ class TopicMismatchError(InvalidMessageError):
         ).format(**self.kwargs)
 
 
+class PrivateTestCaseMismatchError(InvalidMessageError):
+    def __init__(self, **kwargs):
+        super(PrivateTestCaseMismatchError, self).__init__()
+        self.kwargs = kwargs
+
+    def __str__(self):
+        return (
+            'Test case "{testcase_name}" is private (matches "{testcase_glob}") but '
+            'message JMSXUserID "{msg_publisher_id}" does not match "{publisher_id}"'
+        ).format(**self.kwargs)
+
+
 class CreateResultError(RuntimeError):
     def __init__(self, msg, payload):
         super(CreateResultError, self).__init__()

--- a/tox.ini
+++ b/tox.ini
@@ -19,4 +19,4 @@ commands =
 basepython = python2
 skip_install = true
 deps = flake8
-commands = flake8 --ignore E731 --exclude .tox,.git
+commands = flake8 --ignore E731,W503 --exclude .tox,.git


### PR DESCRIPTION
Adds new option "resultsdb-updater.private_testcase_publisher_map"
mapping test case names to JMSXUserID message property. If a test case
name matches glob pattern but not the JMSXUserID value in the message,
new result won't be stored in ResultsDB (the message is rejected).

JIRA: CPAAS-2441